### PR TITLE
print redirect location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ script:
   - awesome_bot bin/assets/test-dupe --allow-dupe
   - awesome_bot bin/assets/test-timeout --allow-timeout --set-timeout 1
   - awesome_bot bin/assets/test-timeout-and-redirect --allow-timeout --set-timeout 1 --allow-redirect
+  - awesome_bot bin/assets/test-redirect --allow-redirect
   - awesome_bot README.md --allow-dupe --white-list gph.is,bot.svg,codeload,badge,rubydoc

--- a/bin/assets/test-redirect
+++ b/bin/assets/test-redirect
@@ -1,0 +1,1 @@
+https://github.com/supermarin/Alcatraz

--- a/lib/awesome_bot/cli.rb
+++ b/lib/awesome_bot/cli.rb
@@ -24,6 +24,7 @@ module AwesomeBot
       print "#{s} " unless s == STATUS_ERROR
       print "#{x['url']}"
       print " #{x['error']}" if s == STATUS_ERROR
+      print " #{STATUS_REDIRECT} #{x['headers']['location']}" if s > 299 && s <400
       puts ''
     end
 

--- a/lib/awesome_bot/statuses.rb
+++ b/lib/awesome_bot/statuses.rb
@@ -7,11 +7,11 @@ module AwesomeBot
 
   class << self
     def net_head_status(url)
-      Faraday.head(url).status
+      Faraday.head(url)
     end
 
     def net_get_status(url)
-      Faraday.get(url).status
+      Faraday.get(url)
     end
 
     def net_status(url, head)
@@ -22,14 +22,17 @@ module AwesomeBot
       statuses = []
       Parallel.each(links, in_threads: threads) do |u|
         begin
-          status = net_status u, head
+          response = net_status u, head
+          status = response.status
+          headers = response.headers
         rescue => e
           status = STATUS_ERROR
+          headers = {}
           error = e
         end
 
         yield status, u
-        statuses.push('url' => u, 'status' => status, 'error' => error)
+        statuses.push('url' => u, 'status' => status, 'error' => error, 'headers' => headers)
       end # Parallel
 
       statuses


### PR DESCRIPTION
Addresses the first part of #30 

@dkhamsing, @Kikobeats I added a commit that would add an extra msg for redirect locations. Here's how it looks in use:
```
$ awesome_bot bin/assets/test-redirect
> Checking links in bin/assets/test-redirect
Links found: 1
  1. https://github.com/supermarin/Alcatraz
Checking URLs: →

Issues :-(
> Links
1. 301 https://github.com/supermarin/Alcatraz → https://github.com/alcatraz/Alcatraz
> Dupes
  None ✓
```

Before I submit a PR, couple questions on the commit (@dkhamsing, you're lacking a `CONTRIBUTING.md`, which may or may not answer some of these questions):
- It looks like the extent of your testing it the handful of use cases in travis. But for this use case, it wouldn't really suffice since the error msg only gets printed if you leave off the `--allow-redirect` flag, but that would fail travis. I would suggest a real testing framework, but that may not be high on your agenda at the moment. Either way, I'd suggest making an issue out of it.
- There's some DRY red flags going on with that `if s > 299 && s <400` tidbit. It's repeated in the `Result` class. Not being super familiar with the code, I didn't see an obvious way rectify that other than create a static util `is_redirect?` method somewhere. But that still feels redundant. I would assume Faraday has that somewhere, but I don't see it. Anybody know if it already exists? If not, I'll add a util method.

My next couple of questions/comments are more just a well-intentioned code review of the code in general. Just little things I noticed as I was walking through the code. This seems as good of place as any to serve them up.

- The use of `Parallel` here seems good to me. Never messed with that library but it was pretty intuitive to me what was going on. :+1: 
- For the `statuses.push('url' => u, 'status' => status, 'error' => error)` line in `statuses.rb`, was there any thought to just letting `statuses` be an array of the Faraday responses themselves? Or a small awesome_bot-specific wrapper class around the response? If you end up needing another attribute like headers, it could get a little verbose to have to put each one explicitly. But you may never need another one.
- I think it might be best practice to explicitly declare the `error` variable as nil on that line so it's clear it is nil in success state.