### PR TITLE
Added space from "redirects to " to the url

### DIFF
--- a/lib/awesome_bot/write.rb
+++ b/lib/awesome_bot/write.rb
@@ -37,7 +37,7 @@ module AwesomeBot
             status = s==-1? 'Error' : "[#{s}](https://httpstatuses.com/#{s})"
             message << "#{loc} | #{status} | #{link} "
             message << "<br> #{error}" unless error ==''
-            message << "redirects to<br>#{r}" unless r==''
+            message << "redirects to <br>#{r}" unless r==''
           end
           message << "\n"
         end


### PR DESCRIPTION
Soooo, I've been seeing this a lot on AwesomeiOS:

<img width="669" alt="screen shot 2016-11-22 at 11 36 37 pm" src="https://cloud.githubusercontent.com/assets/6511079/20553858/929b49ce-b10c-11e6-80c9-1fab47240788.png">
