### PR TITLE
Fixes #148 Add -v to display version information of the gem

### DIFF
--- a/awesome_bot.gemspec
+++ b/awesome_bot.gemspec
@@ -23,3 +23,4 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'parallel', '1.11.2' # threading
 end
+

--- a/lib/awesome_bot/cli.rb
+++ b/lib/awesome_bot/cli.rb
@@ -26,8 +26,9 @@ module AwesomeBot
         opts.on('--base-url [base url]',           String,    'Base URL to use for relative links') { |val| options['base_url'] = val }
         opts.on('-d', '--request-delay [seconds]', Integer,   'Set request delay')                  { |val| options['delay'] = val }
         opts.on('-t', '--set-timeout [seconds]',   Integer,   'Set connection timeout')             { |val| options['timeout'] = val }
-        opts.on('--skip-save-results',             TrueClass, 'Skip saving results')                { |val| options['no_results'] = val }        
+        opts.on('--skip-save-results',             TrueClass, 'Skip saving results')                { |val| options['no_results'] = val }
         opts.on('-w', '--white-list [urls]',       Array,     'Comma separated URLs to white list') { |val| options['white_list'] = val }
+        opts.on('-v', '--version',                 String,    'Display version')                    { |val| puts "#{PROJECT} version #{VERSION}" }
 
         opts.on_tail("--help") do
           puts opts


### PR DESCRIPTION
Fix #148 

```
$ awesome_bot -h
Usage: awesome_bot [file or files] 
       awesome_bot [options]
    -f, --files [files]              Comma separated files to check
    -a, --allow [errors]             Status code errors to allow
        --allow-dupe                 Duplicate URLs are allowed
        --allow-ssl                  SSL errors are allowed
        --allow-redirect             Redirected URLs are allowed
        --allow-timeout              URLs that time out are allowed
        --base-url [base url]        Base URL to use for relative links
    -d, --request-delay [seconds]    Set request delay
    -t, --set-timeout [seconds]      Set connection timeout
        --skip-save-results          Skip saving results
    -w, --white-list [urls]          Comma separated URLs to white list
    -v, --version                    Display version
        --help

$ awesome_bot --version
Awesome_bot version 1.17.1

$ awesome_bot -v
Awesome_bot version 1.17.1
```

@dkhamsing , let me know if you didn't like the format `gemname version <version>` which is same format as that of bundler 
```
$ bundle -v
Bundler version 1.15.4
```
