### PR TITLE
Stricter parsing of relative urls

### DIFF
--- a/bin/assets/test-timeout
+++ b/bin/assets/test-timeout
@@ -1,2 +1,2 @@
-http://www.cmr.osu.edu/browse/datasets
+http://1.2.3.4
 https://github.com

--- a/bin/assets/test-timeout-and-redirect
+++ b/bin/assets/test-timeout-and-redirect
@@ -1,3 +1,3 @@
-http://www.cmr.osu.edu/browse/datasets
+http://1.2.3.4
 https://github.com
 https://github.com/supermarin/Alcatraz

--- a/lib/awesome_bot/links.rb
+++ b/lib/awesome_bot/links.rb
@@ -45,9 +45,10 @@ module AwesomeBot
     end
 
     def get_relative_links(content, base)
-      links = content.scan /\].*?\)/
+      links = []
+      content.scan(/\[[^\]]+\] \( <? ([^)<>]+) >? \)/x) { |groups| links << groups.first }
+
       links.reject { |x| x.include?('http') || x.include?('#') }
-        .map { |x| x.sub '](', ''}
         .map { |x| x =~ /\S/ ? x.match(/^\S*/) : x }
         .map { |x| "#{base}#{x}"}
     end

--- a/lib/awesome_bot/links.rb
+++ b/lib/awesome_bot/links.rb
@@ -1,5 +1,14 @@
 # Get and filter links
 module AwesomeBot
+  # This matches, from left to right:
+  # a literal [
+  # the link title - i.e. anything up to the next closing bracket
+  # a literal ]
+  # a literal (
+  # the link destination (optionally enclosed in a single pair of angle brackets)
+  # a literal )
+  MARKDOWN_LINK_REGEX = /\[ [^\]]+ \] \( <? ([^)<>]+) >? \)/x
+
   class << self
     def links_filter(list)
       list.reject { |x| x.length < 9 }
@@ -46,7 +55,7 @@ module AwesomeBot
 
     def get_relative_links(content, base)
       links = []
-      content.scan(/\[[^\]]+\] \( <? ([^)<>]+) >? \)/x) { |groups| links << groups.first }
+      content.scan(MARKDOWN_LINK_REGEX) { |groups| links << groups.first }
 
       links.reject { |x| x.include?('http') || x.include?('#') }
         .map { |x| x =~ /\S/ ? x.match(/^\S*/) : x }

--- a/spec/parse_spec.rb
+++ b/spec/parse_spec.rb
@@ -135,29 +135,32 @@ describe AwesomeBot do
       end
     end
 
-    context 'given base url and reltive link' do
-      content = '**[Getting Started](notebooks/Getting_Started.ipynb)**: How to connect, some simple data access'
-      base = 'https://github.com/IDR/idr-notebooks/blob/master/'
-      list = AwesomeBot::links_find content, base
-      f = AwesomeBot::links_filter list
-      value = f[0]
-      expected = 'https://github.com/IDR/idr-notebooks/blob/master/notebooks/Getting_Started.ipynb'
-      it "parses correctly" do
+    context 'given a base url' do
+      let(:base) { 'https://github.com/IDR/idr-notebooks/blob/master/' }
+
+      it 'parses a relative link' do
+        content = '**[Getting Started](notebooks/Getting_Started.ipynb)**: How to connect, some simple data access'
+        list = AwesomeBot::links_find content, base
+        f = AwesomeBot::links_filter list
+        value = f[0]
+        expected = 'https://github.com/IDR/idr-notebooks/blob/master/notebooks/Getting_Started.ipynb'
         expect(value).to eql(expected)
       end
-    end
 
-    context 'given base url and relative link with hover title text' do
-      content = '![oauth login](/includes/login_1.png?raw=true "OAuth login")'
-      base = 'https://github.com/IDR/idr-notebooks/blob/master/'
-      list = AwesomeBot::links_find content, base
-      f = AwesomeBot::links_filter list
-      value = f[0]
-      expected = 'https://github.com/IDR/idr-notebooks/blob/master//includes/login_1.png?raw=true'
-      it "parses correctly" do
+      it 'parses a relative link with hover title text' do
+        content = '![oauth login](/includes/login_1.png?raw=true "OAuth login")'
+        list = AwesomeBot::links_find content, base
+        f = AwesomeBot::links_filter list
+        value = f[0]
+        expected = 'https://github.com/IDR/idr-notebooks/blob/master//includes/login_1.png?raw=true'
         expect(value).to eql(expected)
       end
-    end
 
+      it 'ignores bracket characters that do not form a valid URL' do
+        content = '`(String args[])`'
+        list = AwesomeBot::links_find content, base
+        expect(AwesomeBot::links_filter list).to be_empty
+      end
+    end
   end
 end

--- a/spec/parse_spec.rb
+++ b/spec/parse_spec.rb
@@ -159,7 +159,19 @@ describe AwesomeBot do
       it 'ignores bracket characters that do not form a valid URL' do
         content = '`(String args[])`'
         list = AwesomeBot::links_find content, base
-        expect(AwesomeBot::links_filter list).to be_empty
+        expect(list).to be_empty
+      end
+
+      it 'parses multiple links on the same line' do
+        content = '[link 1](foo) [link 2](bar)'
+        list = AwesomeBot::links_find content, base
+        expect(list).to eq([base + 'foo', base + 'bar'])
+      end
+
+      it 'ignores empty links' do
+        content = '[link]() [link](<>)'
+        list = AwesomeBot::links_find content, base
+        expect(list).to be_empty
       end
     end
   end

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -64,17 +64,6 @@ describe AwesomeBot do
     #   end
     # end
 
-    context "given a header with special encoding" do
-      link = 'http://okeowoaderemi.com/site/assets/files/1103/zf2-flowchart.jpg'
-      r = AwesomeBot::check link
-      s = r.status[0]
-      value = s['headers']['strict-transport-security']
-      expected = '“max-age=31536000″'
-      it "is encoded using utf8" do
-        expect(value).to eql(expected)
-      end
-    end
-
     context "given an incomplete redirect" do
       link = 'https://godoc.org/github.com/ipfs/go-libp2p-crypto'
       r = AwesomeBot::check link

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -65,11 +65,11 @@ describe AwesomeBot do
     # end
 
     context "given an incomplete redirect" do
-      link = 'https://godoc.org/github.com/ipfs/go-libp2p-crypto'
+      link = 'https://httpbin.org/redirect-to?url=/foo&status_code=301'
       r = AwesomeBot::check link
       s = r.status[0]
       value = s['headers']['location']
-      expected = 'https://godoc.org/github.com/libp2p/go-libp2p-crypto'
+      expected = 'https://httpbin.org/foo'
       it "the redirect is adjusted" do
         expect(value).to eql(expected)
       end

--- a/spec/timeout_spec.rb
+++ b/spec/timeout_spec.rb
@@ -2,7 +2,7 @@ require 'awesome_bot'
 
 describe AwesomeBot do
   describe "timeout" do
-    timeoutlink = 'http://www.cmr.osu.edu/browse/datasets'
+    timeoutlink = 'http://1.2.3.4'
     options = {'timeout'=>1}
 
     context "given a timeout link and setting timeout to 1s" do


### PR DESCRIPTION
I noticed that when passing a base URL to awesome bot, it picks up things that aren't URLs.

For example, I put some java code in a code block, and awesome bot reported it as a bad URI:

```java
public class HelloWorld {
	public static void main(String args[]){
		System.out.println("Hello World");
	}
}
```

I've changed the regex so that the link target has to directly follow the link text, and added some more tests.

The link parsing logic is still quite complex, and there are edge cases that still won't work, so it may be worth replacing it with a markdown parser instead. For now I've just tried to make it handle a few more cases correctly.

For more details of valid and invalid links in markdown, see https://spec.commonmark.org/0.28/#links