### PR TITLE
Use webmock for tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec
 gem 'rspec_junit_formatter', '0.2.3' # test meta data / ci
 gem 'rspec', '3.6.0' # tests'
+gem 'webmock', '~> 3.4', '>= 3.4.2' # tests

--- a/bin/assets/test-timeout
+++ b/bin/assets/test-timeout
@@ -1,2 +1,2 @@
-http://www.cmr.osu.edu/browse/datasets
+http://1.2.3.4
 https://github.com

--- a/bin/assets/test-timeout-and-redirect
+++ b/bin/assets/test-timeout-and-redirect
@@ -1,3 +1,3 @@
-http://www.cmr.osu.edu/browse/datasets
+http://1.2.3.4
 https://github.com
 https://github.com/supermarin/Alcatraz

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -1,4 +1,4 @@
-require 'awesome_bot'
+require 'spec_helper'
 
 describe AwesomeBot do
   describe "check" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'webmock/rspec'
+require 'awesome_bot'
+
+WebMock.allow_net_connect!

--- a/spec/timeout_spec.rb
+++ b/spec/timeout_spec.rb
@@ -2,7 +2,7 @@ require 'awesome_bot'
 
 describe AwesomeBot do
   describe "timeout" do
-    timeoutlink = 'http://www.cmr.osu.edu/browse/datasets'
+    timeoutlink = 'http://1.2.3.4'
     options = {'timeout'=>1}
 
     context "given a timeout link and setting timeout to 1s" do


### PR DESCRIPTION
Hi @dkhamsing 

Because of the test issues I found in https://github.com/dkhamsing/awesome_bot/pull/172 I had ago at rewriting some of them. 

This uses webmock to stub out HTTP requests instead of actually requesting real websites. What do you think of this approach?

I only changed a few broken ones for now, but I noticed other tests that are quite flaky at the moment because the servers they hit don't behave consistently.

For example, if I query the httpbin site (used in check_spec.rb) through curl, every now and again it will serve a 301 response instead of a 200:

```
$ curl -i 'http://user:passwd@httpbin.org/basic-auth/user/passwd'
HTTP/1.1 200 OK
Connection: keep-alive
Server: gunicorn/19.8.1
Date: Thu, 05 Jul 2018 15:11:28 GMT
Content-Type: application/json
Content-Length: 37
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Via: 1.1 vegur

{"authenticated":true,"user":"user"}
$ curl -i 'http://user:passwd@httpbin.org/basic-auth/user/passwd'
HTTP/1.1 301 Moved Permanently
Date: Thu, 05 Jul 2018 15:11:29 GMT
Content-Type: text/plain
Transfer-Encoding: chunked
Connection: keep-alive
Location: https://httpbin.org/basic-auth/user/passwd
x-now-trace: bru1
server: now
cache-control: max-age=0
```