### PR TITLE
Using 'ruby:alpine' to dramatically change image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:alpine
 
 RUN gem install awesome_bot --no-format-exec
 


### PR DESCRIPTION
Went from image size of 868MB to 47.6MB using the `ruby:alpine` baseimage. Tested OK in my projects 👍 