### PR TITLE
Handle javadoc links

### DIFF
--- a/lib/awesome_bot/links.rb
+++ b/lib/awesome_bot/links.rb
@@ -18,6 +18,8 @@ module AwesomeBot
         .map do |x|
           if x.include? ')]'
             x.gsub /\)\].*/, ''
+          elsif (x.scan(')').count == 1) && (x.scan('(').count == 1)
+            x
           elsif (x.scan(')').count == 2) && (x.scan('(').count == 1)
             x.gsub(/\)\).*/, ')')
           elsif (x.scan(')').count > 0)

--- a/spec/parse_spec.rb
+++ b/spec/parse_spec.rb
@@ -40,7 +40,7 @@ describe AwesomeBot do
       end
     end
 
-    context "given links spearated by comma" do
+    context "given links separated by comma" do
       content = 'https://github.com/dkhamsing, https://twitter.com/dkhamsing'
       list = AwesomeBot::links_find content
       f = AwesomeBot::links_filter list
@@ -95,7 +95,7 @@ describe AwesomeBot do
       end
     end
 
-    context 'given a wikipedia link with parentheses' do
+    context 'given a link with fragment and parentheses' do
       content = 'https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Reader.html#nullReader()'
       list = AwesomeBot::links_find content
       f = AwesomeBot::links_filter list
@@ -106,6 +106,16 @@ describe AwesomeBot do
       end
     end
 
+    context 'given a markdown link with fragment and parentheses' do
+      content = '[JAVADOC](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Reader.html#nullReader())'
+      list = AwesomeBot::links_find content
+      f = AwesomeBot::links_filter list
+      value = f[0]
+      expected = 'https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Reader.html#nullReader()'
+      it "parses correctly" do
+        expect(value).to eql(expected)
+      end
+    end
 
     context 'given a markdown wikipedia link' do
       content = '[TAL](https://en.wikipedia.org/wiki/Template_Attribute_Language)'

--- a/spec/parse_spec.rb
+++ b/spec/parse_spec.rb
@@ -95,6 +95,18 @@ describe AwesomeBot do
       end
     end
 
+    context 'given a wikipedia link with parentheses' do
+      content = 'https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Reader.html#nullReader()'
+      list = AwesomeBot::links_find content
+      f = AwesomeBot::links_filter list
+      value = f[0]
+      expected = 'https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Reader.html#nullReader()'
+      it "parses correctly" do
+        expect(value).to eql(expected)
+      end
+    end
+
+
     context 'given a markdown wikipedia link' do
       content = '[TAL](https://en.wikipedia.org/wiki/Template_Attribute_Language)'
       list = AwesomeBot::links_find content


### PR DESCRIPTION
Hello,

 (thank you for this nice project!)
 
  I noticed that links to javadoc are not working properly, e.g.

https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Reader.html#nullReader()

is parsed as:

https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Reader.html#nullReader(

This PR provides two tests and a very naive fix (feel free to change or improve it).

