### PR TITLE
Option to completely skip checking white listed URLs

### DIFF
--- a/Dockerfile.local_source
+++ b/Dockerfile.local_source
@@ -1,0 +1,28 @@
+# This is an alternate docker build that will build and install awesome_bot
+# from source right here rather than installing a cached version in the Gem repo
+
+# Sample Usage:
+#     docker build . -t awesome_bot:local -f Dockerfile.local_source
+
+
+### Stage 1: Build the gem for internal use
+
+FROM ruby:alpine AS builder
+COPY . /src
+RUN apk --no-cache add git && \
+    cd /src && \
+    gem build awesome_bot.gemspec
+
+
+### Stage 2: Build the deliverable docker image
+
+FROM ruby:alpine
+
+# Get the gem from the builder image, and install it from a CWD
+COPY --from=builder /src/awesome_bot-*.gem /tmp/awesome_bot.gem
+RUN cd /tmp && gem install awesome_bot --no-format-exec
+
+VOLUME /mnt
+WORKDIR /mnt
+ENTRYPOINT ["awesome_bot"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Usage: awesome_bot [file or files]
     -t, --set-timeout [seconds]      Set connection timeout (default: 30)
         --skip-save-results          Skip saving results
     -w, --white-list [urls]          Comma separated URLs to white list
+        --skip-white-list            Skip checking white listed URLs
+    -v, --version                    Display version
+        --help
 ```
 
 - You can check multiple files (comma separated or `*` pattern, look below for details).

--- a/lib/awesome_bot/check.rb
+++ b/lib/awesome_bot/check.rb
@@ -9,12 +9,14 @@ module AwesomeBot
     def check(content, options=nil, number_of_threads=1)
       if options.nil?
         white_listed = nil
+        skip_white_listed = false
         skip_dupe = false
         timeout = nil
         delay = 0
         base = nil
       else
         white_listed = options['whitelist']
+        skip_white_listed = options['skipwhitelist']
         skip_dupe = options['allowdupe']
         timeout = options['timeout']
         delay = options['delay']
@@ -49,7 +51,7 @@ module AwesomeBot
         end
       yield "\n" if block_given?
 
-      return r if !r.white_listing || (r.links_white_listed.count == 0)
+      return r if !r.white_listing || (r.links_white_listed.count == 0) || skip_white_listed
 
       yield 'Checking white listed URLs: ' if block_given?
       r.white_listed =

--- a/lib/awesome_bot/cli.rb
+++ b/lib/awesome_bot/cli.rb
@@ -28,6 +28,7 @@ module AwesomeBot
         opts.on('-t', '--set-timeout [seconds]',   Integer,   'Set connection timeout (default: 30)')             { |val| options['timeout'] = val }
         opts.on('--skip-save-results',             TrueClass, 'Skip saving results')                { |val| options['no_results'] = val }
         opts.on('-w', '--white-list [urls]',       Array,     'Comma separated URLs to white list') { |val| options['white_list'] = val }
+        opts.on('--skip-white-list',               TrueClass, 'Skip checking white listed URLs')    { |val| options['skip_white_list'] = val }
         opts.on('-v', '--version',                 String,    'Display version')                    { |val| puts "#{PROJECT} version #{VERSION}" }
 
         opts.on_tail("--help") do
@@ -101,6 +102,7 @@ module AwesomeBot
       puts "> Will delay each request by #{delay} second#{delay==1? '': 's'}" unless delay.nil?
 
       white_listed = options['white_list']
+      skip_white_list = options['skip_white_list']
 
       timeout = options['timeout']
       puts "> Connection timeout = #{timeout}s" unless timeout.nil?
@@ -119,6 +121,7 @@ module AwesomeBot
         'delay' => delay,
         'timeout'   => timeout,
         'whitelist' => white_listed,
+        'skipwhitelist' => skip_white_list,
         'baseurl' => base
       }
 

--- a/lib/awesome_bot/version.rb
+++ b/lib/awesome_bot/version.rb
@@ -5,5 +5,5 @@ module AwesomeBot
                         'Great for "awesome" projects.'
   PROJECT_URL = 'https://github.com/dkhamsing/awesome_bot'
 
-  VERSION = '1.18.0'
+  VERSION = '1.18.1'
 end


### PR DESCRIPTION
I need this feature to prevent downloading very large files that are discoverable in my docs. If this mode is too broad, I could instead make a --skip-list in the same notation as --white-list. Let me know if that would be better.

Thanks